### PR TITLE
fix #3 - use current terminal width as default

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ The pager used is determined by system configuration in this order of preference
 
     -s, --section=TITLE              Output only a headline-based section of 
                                      the input
-    -w, --width=COLUMNS              Column width to format for (default 80)
+    -w, --width=COLUMNS              Column width to format for (default terminal width)
     -p, --[no-]pager                 Formatted output to pager (default on)
     -P                               Disable pager (same as --no-pager)
     -c, --[no-]color                 Colorize output (default on)

--- a/lib/mdless/converter.rb
+++ b/lib/mdless/converter.rb
@@ -21,12 +21,9 @@ module CLIMarkdown
           @options[:section] = section
         end
 
-        @options[:width] = 80
-        opts.on( '-w', '--width=COLUMNS', 'Column width to format for (default 80)' ) do |columns|
+        @options[:width] = %x{tput cols}.strip.to_i
+        opts.on( '-w', '--width=COLUMNS', 'Column width to format for (default terminal width)' ) do |columns|
           @options[:width] = columns.to_i
-          if @options[:width] = 0
-            @options[:width] = %x{tput cols}.strip.to_i
-          end
         end
 
         @options[:pager] = true
@@ -96,7 +93,7 @@ module CLIMarkdown
 
       optparse.parse!
 
-      @cols = @options[:width] || %x{tput cols}.strip.to_i * 0.9
+      @cols = @options[:width]
       @output = ''
 
       input = ''


### PR DESCRIPTION
change default width from 80 to width of terminal

`@cols` never got set to 90% of terminal width because `@options[:width]`
defaulted to 80.