### PR TITLE
fix #1 - crash on github-compatible markdown

### DIFF
--- a/lib/mdless/converter.rb
+++ b/lib/mdless/converter.rb
@@ -417,7 +417,8 @@ module CLIMarkdown
             new_code_line = l.gsub(/\t/,'    ')
             orig_length = new_code_line.size + 3
             new_code_line.gsub!(/ /,"#{c([:x,:white,:on_black])} ")
-            "#{c([:x,:black])}~ #{c([:x,:white,:on_black])} " + new_code_line + c([:x,:white,:on_black]) + " "*(@cols - orig_length) + xc
+            pad_count = [@cols - orig_length, 0].max
+            "#{c([:x,:black])}~ #{c([:x,:white,:on_black])} " + new_code_line + c([:x,:white,:on_black]) + " "*pad_count + xc
           }.join("\n")
         end
         "#{c([:x,:magenta])}#{leader}\n#{hilite}#{xc}"


### PR DESCRIPTION
Fix error when pygmentize not available and code block line length exceeds --width.  Fix by preventing negative values to String multiplication.
