### PR TITLE
use only the first word after '```/~~~' as language name

### DIFF
--- a/lib/mdless/converter.rb
+++ b/lib/mdless/converter.rb
@@ -435,9 +435,11 @@ module CLIMarkdown
             codeBlock = m[3].to_s.gsub(shebang[1]+shebang[2], '').strip
             leader = shebang[2] ? shebang[2].upcase + ':' : 'CODE:'
         else
-            language = m[2]
+            # Ignore leading spaces, and use only first word
+            # so ("``` js whatever") will result in language == "js"
+            language = m[2] ? m[2].to_s.match(/\s*([\S]*)[\s\S]*?/)[1] : nil
             codeBlock = m[3]
-            leader = m[2] ? m[2].upcase + ":" : 'CODE:'
+            leader = language ? language.upcase + ":" : 'CODE:'
         end
         leader += xc
         hiliteCode(language, codeBlock, leader, m[0])


### PR DESCRIPTION
I believe all language names used in this place are single word, and most tools
(like github) will ignore any additional words. However some tools use the extra
words for other purposes, so its best to ignore those since otherwise `mdless`
fails to parse files which provide the extra info for those tools.

For example, the following [mdsh](https://github.com/bashup/mdsh) code block
will fail to display correctly in `mdless`:
```bash @mdsh
mdsh-lang-python() { python; }
```