### PR TITLE
fix code blocks without language tag

### DIFF
--- a/lib/mdless/converter.rb
+++ b/lib/mdless/converter.rb
@@ -437,7 +437,7 @@ module CLIMarkdown
         else
             # Ignore leading spaces, and use only first word
             # so ("``` js whatever") will result in language == "js"
-            language = m[2] ? m[2].to_s.match(/\s*([\S]*)[\s\S]*?/)[1] : nil
+            language = m[2] != '' ? m[2].to_s.match(/\s*([\S]*)[\s\S]*?/)[1] : nil
             codeBlock = m[3]
             leader = language ? language.upcase + ":" : 'CODE:'
         end


### PR DESCRIPTION
I believe i might have introduced this bug in #21 (thanks for the fast merge btw) 

for code blocks with no language tag, the `language` variable would be 
set to empty string, which then was passed as `-l` option to `pygmentize`
resulting in the code block being rendered as empty. The `leader` would also end up as `:`.

To fix it, we are setting `language` to `nil` if the tag is not present.