### PR TITLE
Making STDIN work for not-ready IO data (ie. block)

### DIFF
--- a/lib/mdless/converter.rb
+++ b/lib/mdless/converter.rb
@@ -14,7 +14,7 @@ module CLIMarkdown
 
       @options = {}
       optparse = OptionParser.new do |opts|
-        opts.banner = "#{version} by Brett Terpstra\n\n> Usage: #{CLIMarkdown::EXECUTABLE_NAME} [options] path\n\n"
+        opts.banner = "#{version} by Brett Terpstra\n\n> Usage: #{CLIMarkdown::EXECUTABLE_NAME} [options] [path]\n\n"
 
         @options[:section] = nil
         opts.on( '-s', '--section=TITLE', 'Output only a headline-based section of the input (numeric from -l)' ) do |section|
@@ -119,7 +119,7 @@ module CLIMarkdown
           end
         }
         printout
-      elsif STDIN.stat.size > 0
+      elsif ! STDIN.tty?
         @file = nil
         begin
           input = STDIN.read.force_encoding('utf-8')


### PR DESCRIPTION
This change will allow to work with `mdless` with output from commands that doesn't have data ready right away. IE (my example):

```
hub issue show 123 | mdless
```

or some other:
```
curl https://kubek2k.org/xyz.md | mdless
```