### PR TITLE
Ignore errors from which(1)

### DIFF
--- a/lib/mdless/converter.rb
+++ b/lib/mdless/converter.rb
@@ -906,7 +906,7 @@ module CLIMarkdown
       if File.exists?(File.expand_path(cli))
         File.executable?(File.expand_path(cli))
       else
-        system "which #{cli}", :out => File::NULL
+        system "which #{cli}", :out => File::NULL, :err => File::NULL
       end
     end
 
@@ -980,7 +980,7 @@ module CLIMarkdown
           if f.strip =~ /[ |]/
             f
           else
-            system "which #{f}", :out => File::NULL
+            system "which #{f}", :out => File::NULL, :err => File::NULL
           end
         else
           false


### PR DESCRIPTION
Couldn't think of a good reason to see error messages from which when it can't find one of the pagers.