### PR TITLE
rescue command line parsing errors and output an error message instead of a stack trace

### DIFF
--- a/lib/mdless/converter.rb
+++ b/lib/mdless/converter.rb
@@ -104,7 +104,12 @@ module CLIMarkdown
         end
       end
 
-      optparse.parse!
+      begin
+        optparse.parse!
+      rescue OptionParser::ParseError => pe
+        $stderr.puts "error: #{pe.message}"
+        exit 1
+      end
 
       @theme = load_theme(@options[:theme])
       @cols = @options[:width]


### PR DESCRIPTION
I think this makes it a little more friendly when you mistype a command line option.