### PR TITLE
optionally pad code blocks with regular spaces instead of NBSP characters. 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ mdless.sublime-*
 Gemfile.lock
 vendor
 .tool-versions
+.devbox

--- a/README.md
+++ b/README.md
@@ -82,6 +82,8 @@ The pager used is determined by system configuration in this order of preference
         --links=FORMAT               Link style ([inline, reference, paragraph], default inline,
                 "paragraph" will position reference links after each paragraph)
         --[no-]linebreaks            Preserve line breaks
+        --[no-]nbsp-padding          Pad code blocks and metadata headers with non-breaking spaces
+                                     (default on; disable for clipboard-safe yank+paste in tmux et al)
         --[no-]syntax                Syntax highlight code blocks
         --taskpaper=OPTION           Highlight TaskPaper format (true|false|auto)
         --update_config              Update the configuration file with new keys and current command line options
@@ -101,6 +103,7 @@ The first time mdless is run, a config file will be written to `~/.config/mdless
 :lax_spacing: true
 :links: :paragraph
 :local_images: true
+:nbsp_padding: true
 :pager: true
 :preserve_linebreaks: false
 :remote_images: false
@@ -119,6 +122,7 @@ The first time mdless is run, a config file will be written to `~/.config/mdless
 - `:lax_spacing` determines whether a blank line is required around HTML elements.
 - `:links` can be `inline`, `reference`, or `paragraph`. Paragraph puts reference links directly after the graf that refers to them.
 - `:local_images` determines whether local images are processed using `chafa` or `imgcat` (whichever is available). `:remote_images` does the same for images referenced with web urls. If `:remote_images` is true, then `:local_images` is automatically enabled.
+- `:nbsp_padding` controls the character used to right-pad fenced code blocks and metadata header lines out to a uniform block width. When `true` (the default, preserving historical behavior), padding is rendered with non-breaking spaces (U+00A0) so it survives `String#strip` and similar transforms. Set to `false` to use regular ASCII spaces instead, which makes terminal selections (e.g. tmux `shift+v`) yank a shell-safe string — non-breaking spaces are not treated as whitespace by most shells and otherwise get glued to the last argument of a pasted command.
 - `:pager` turns on or off pagination using `less` or closest available substitute.
 - `:preserve_linebreaks` determines whether hard breaks within paragraphs are preserved. When converting to HTML, most Markdown processors will cause consecutive lines to be merged together, which is the default behavior for `mdless`. Turning this option on will cause lines to remain hard wrapped.
 - `:syntax_highlight` will turn on/off syntax highlighting of code blocks (requires Pygments)

--- a/lib/mdless/console.rb
+++ b/lib/mdless/console.rb
@@ -59,8 +59,9 @@ module Redcarpet
       end
 
       def code_bg(input, width)
+        pad_char = MDLess.options[:nbsp_padding] ? "\u00A0" : ' '
         input.split(/\n/).map do |line|
-          tail = line.uncolor.length < width ? "\u00A0" * (width - line.uncolor.length) : ''
+          tail = line.uncolor.length < width ? pad_char * (width - line.uncolor.length) : ''
           "#{x}#{line}#{tail}#{x}"
         end.join("\n")
       end
@@ -744,6 +745,7 @@ module Redcarpet
         input = text.dup
         input.clean_empty_lines!
         MDLess.meta = {}
+        pad_char = MDLess.options[:nbsp_padding] ? "\u00A0" : ' '
         first_line = input.split("\n").first
         if first_line =~ /(?i-m)^---[ \t]*?$/
           MDLess.log.info('Found YAML')
@@ -773,7 +775,7 @@ module Redcarpet
                 line = "#{color('metadata marker')}% #{color('metadata color')}#{line}"
               end
               if (longest - line.uncolor.strip.length).positive?
-                line += "\u00A0" * (longest - line.uncolor.strip.length)
+                line += pad_char * (longest - line.uncolor.strip.length)
               end
               line + xc
             end.join("\n") + "#{xc}\n"
@@ -799,7 +801,7 @@ module Redcarpet
               end
               line = "#{color('metadata marker')}%#{color('metadata color')}#{line}"
               if (longest - line.uncolor.strip.length).positive?
-                line += "\u00A0" * (longest - line.uncolor.strip.length)
+                line += pad_char * (longest - line.uncolor.strip.length)
               end
               line + xc
             end.join("\n") + "#{xc}\n"

--- a/lib/mdless/converter.rb
+++ b/lib/mdless/converter.rb
@@ -196,6 +196,13 @@ module CLIMarkdown
           MDLess.options[:mmd_metadata] = opt
         end
 
+        default(:nbsp_padding, true)
+        opts.on("--[no-]nbsp-padding",
+                "Pad code blocks and metadata headers with non-breaking spaces" \
+                " (default true; disable for clipboard-safe yank+paste in terminal multiplexers)") do |opt|
+          MDLess.options[:nbsp_padding] = opt
+        end
+
         default(:syntax_higlight, false)
         opts.on("--[no-]syntax", "Syntax highlight code blocks") do |opt|
           MDLess.options[:syntax_higlight] = opt

--- a/lib/mdless/string.rb
+++ b/lib/mdless/string.rb
@@ -57,6 +57,7 @@ class ::String
     input = dup
     input.clean_empty_lines!
     MDLess.meta = {}
+    pad_char = MDLess.options[:nbsp_padding] ? "\u00A0" : ' '
 
     in_yaml = false
     first_line = input.split("\n").first
@@ -79,7 +80,7 @@ class ::String
             line = "#{color('metadata marker')}%#{color('metadata color')}#{line}#{xc}"
           end
 
-          line += "\u00A0" * (longest - line.uncolor.strip.length) if (longest - line.uncolor.strip.length).positive?
+          line += pad_char * (longest - line.uncolor.strip.length) if (longest - line.uncolor.strip.length).positive?
           line + xc
         end.join("\n") + "#{xc}\n"
       end
@@ -100,9 +101,9 @@ class ::String
           value = parts[2].strip
           MDLess.meta[key] = value
           line = "#{color('metadata color')}#{line}#{xc}"
-          line += "\u00A0" * (longest - line.uncolor.strip.length) if (longest - line.uncolor.strip.length).positive?
+          line += pad_char * (longest - line.uncolor.strip.length) if (longest - line.uncolor.strip.length).positive?
           line + xc
-        end.join("\n") + "#{"\u00A0" * longest}#{xc}\n"
+        end.join("\n") + "#{pad_char * longest}#{xc}\n"
       end
     end
 


### PR DESCRIPTION
When doing something like yanking a whole line from a code block via tmux visual line mode, it selects the non-breaking space padding characters. When pasting that into my terminal, it includes the NBSP characters which break commands. 
Add a flag nbsp-padding (default true) that when set to false switches these NBSP characters for regular spaces. 