### PR TITLE
Fix codeblock padding

### DIFF
--- a/lib/mdless/console.rb
+++ b/lib/mdless/console.rb
@@ -208,7 +208,11 @@ module Redcarpet
       end
 
       def block_code(code, language)
-        "\n\n#{hilite_code(code, language)}#{xc}\n\n"
+        # Wrap in <<codeblock>>...<</codeblock>> markers so postprocess can
+        # skip the backslash-escape strip inside code-block content (per the
+        # CommonMark spec, backslash-escapes do not apply inside code blocks).
+        # The markers are removed in postprocess after the strip pass.
+        "\n\n<<codeblock>>#{hilite_code(code, language)}#{xc}<</codeblock>>\n\n"
       end
 
       def block_quote(quote)
@@ -1157,8 +1161,19 @@ module Redcarpet
           end.join("\n")
           input = "#{input}\n\n#{footnotes}"
         end
-        # escaped characters
-        input.gsub!(/\\(\S)/, '\1')
+        # Escaped characters: strip backslash-escapes per CommonMark spec
+        # (https://spec.commonmark.org/0.31.2/#backslash-escapes), but only
+        # for the ASCII punctuation set the spec actually recognizes, and
+        # only on non-code-block content. block_code wraps its output in
+        # <<codeblock>>...<</codeblock>> markers so we can isolate those
+        # regions here. The previous `\\(\S)` form ate every backslash-
+        # followed-by-non-space, including `\n \t \s \S \d \w \1 \2 ...`
+        # inside code blocks, which shifted padding-aligned right edges
+        # left by N chars per stripped backslash.
+        input = input.split(%r{(<<codeblock>>.*?<</codeblock>>)}m).map.with_index do |seg, i|
+          i.odd? ? seg : seg.gsub(/\\([!"\#$%&'()*+,\-.\/:;<=>?@\[\\\]^_`{|}~])/, '\1')
+        end.join
+        input.gsub!(%r{<</?codeblock>>}, '')
         # equations
         input = fix_equations(input)
         # misc html

--- a/lib/mdless/console.rb
+++ b/lib/mdless/console.rb
@@ -59,9 +59,15 @@ module Redcarpet
       end
 
       def code_bg(input, width)
+        # NOTE: trailing reset is `xc` (\e[0;37m), not bare `x` (\e[0m).
+        # clean_escapes in converter.rb strips every bare \e[0m from the final
+        # output, so a bare-reset trailer would leak the code-block bg into the
+        # rest of the line (terminals with bce extend bg to the right edge).
+        # \e[0;37m embeds the same `0` reset parameter alongside a fg set, so
+        # it survives clean_escapes and still clears the bg before the newline.
         input.split(/\n/).map do |line|
           tail = line.uncolor.length < width ? "\u00A0" * (width - line.uncolor.length) : ''
-          "#{x}#{line}#{tail}#{x}"
+          "#{x}#{line}#{tail}#{xc}"
         end.join("\n")
       end
 
@@ -122,19 +128,26 @@ module Redcarpet
                                        stdin_data: code_block)
 
             if s.success?
+              # NOTE: do NOT append xc/\n after blackout. blackout's `$` regex
+              # injects the bg-color escape at the end of every line; anything
+              # appended after that becomes part of the last line when code_bg
+              # later splits on \n, and a trailing xc there resets the bg so
+              # the last line's right-padding renders without the block bg.
+              # code_bg now emits its own per-line xc trailer instead.
               hilite = xc + hilite.split(/\n/).map do |l|
                 [
                   color('code_block marker'),
                   MDLess.theme['code_block']['character'],
                   "#{color('code_block bg')}#{l}#{xc}"
                 ].join
-              end.join("\n").blackout(MDLess.theme['code_block']['bg']) + "#{xc}\n"
+              end.join("\n").blackout(MDLess.theme['code_block']['bg'])
             end
           rescue StandardError => e
             MDLess.log.error(e)
             hilite = code_block
           end
         else
+          # See note above re: dropping the trailing xc/\n.
           hilite = code_block.split(/\n/).map do |line|
             [
               color('code_block marker'),
@@ -143,7 +156,7 @@ module Redcarpet
               line,
               xc
             ].join
-          end.join("\n").blackout(MDLess.theme['code_block']['bg']) + "#{xc}\n"
+          end.join("\n").blackout(MDLess.theme['code_block']['bg'])
         end
 
         top_border = if language.nil? || language.empty?


### PR DESCRIPTION
Fixes for codeblock padding wrapping around longest col.
Before fix:
<img width="2056" height="778" alt="image" src="https://github.com/user-attachments/assets/c1f4dfe0-e310-4883-8847-feb324a5c3d1" />
After escape code fix:
<img width="2056" height="792" alt="image" src="https://github.com/user-attachments/assets/63ee7f48-06ea-49a7-9357-6967a4c36a91" />
After fix: 
<img width="2056" height="932" alt="image" src="https://github.com/user-attachments/assets/cbf53663-1f3d-44bd-8a97-de2b5bfd2e97" />