### PR TITLE
fix version numbers plus accidental xc escape code regression

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+2.1.65
+: add nbsp_padding flag to toggle Non breaking space characters as right-padding
+: for code blocks.
+
+2.1.64
+
+2.1.63
+: Missing logger in Ruby 4.0.1, added to gemspec
+
 2.1.60
 
 2.1.61
@@ -244,8 +253,3 @@
 : Better language detection for code blocks
 : when available, use italic font for italics and bold-italics emphasis
 : new colorization for html tags
-
-2.1.63
-: Missing logger in Ruby 4.0.1, added to gemspec
-
-2.1.64

--- a/lib/mdless/console.rb
+++ b/lib/mdless/console.rb
@@ -59,10 +59,16 @@ module Redcarpet
       end
 
       def code_bg(input, width)
+        # NOTE: trailing reset is `xc` (\e[0;37m), not bare `x` (\e[0m).
+        # clean_escapes in converter.rb strips every bare \e[0m from the final
+        # output, so a bare-reset trailer would leak the code-block bg into the
+        # rest of the line (terminals with bce extend bg to the right edge).
+        # \e[0;37m embeds the same `0` reset parameter alongside a fg set, so
+        # it survives clean_escapes and still clears the bg before the newline.
         pad_char = MDLess.options[:nbsp_padding] ? "\u00A0" : ' '
         input.split(/\n/).map do |line|
           tail = line.uncolor.length < width ? pad_char * (width - line.uncolor.length) : ''
-          "#{x}#{line}#{tail}#{x}"
+          "#{x}#{line}#{tail}#{xc}"
         end.join("\n")
       end
 

--- a/lib/mdless/version.rb
+++ b/lib/mdless/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module CLIMarkdown
-  VERSION = '2.1.64'
+  VERSION = '2.1.65'
 end


### PR DESCRIPTION
https://github.com/ttscoff/mdless/commit/bf7d3f60f26df1469df8f4153250b9f569ed8790#diff-d4610c8a258cc0d04a32d8e7e4adcfba50b1ff43402840091b5ff334069dd3a4L62-R66

accidentally removed a change committed in #114 