### PR TITLE
Reset terminal colors after pager exits

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ Gemfile.lock
 vendor
 .tool-versions
 .devbox
+current_changelog.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+2.1.66
+
 2.1.65
 : add nbsp_padding flag to toggle Non breaking space characters as right-padding
 : for code blocks.

--- a/lib/mdless/converter.rb
+++ b/lib/mdless/converter.rb
@@ -556,6 +556,14 @@ module CLIMarkdown
       end.join("\n")
     end
 
+    def reset_terminal
+      return unless MDLess.options[:color]
+
+      # less -r leaves SGR attributes active on the terminal when the last
+      # visible line is colored; reset the real stdout after the pager exits.
+      $stdout.print "\e[0m"
+    end
+
     def page(text, &callback)
       read_io, write_io = IO.pipe
 
@@ -617,6 +625,7 @@ module CLIMarkdown
 
       if MDLess.options[:pager]
         page(out)
+        reset_terminal
       else
         $stdout.print out.rstrip
       end

--- a/lib/mdless/version.rb
+++ b/lib/mdless/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module CLIMarkdown
-  VERSION = '2.1.65'
+  VERSION = '2.1.66'
 end


### PR DESCRIPTION
## Summary
- Print `\e[0m` to stdout after the pager closes when color output is enabled
- Fixes terminal colors (e.g. table headers) persisting after quitting mdless when the last visible line was colored

Fixes #117

## Test plan
- [ ] `mdless test/table.md` — scroll so a colored table header is on the last line, quit with `q`
- [ ] Run `echo "test"` — output should be uncolored
- [ ] Confirm `--no-pager` and `--no-color` behavior unchanged

Made with [Cursor](https://cursor.com)